### PR TITLE
Fix chord parsing for chord symbols containing parentheses

### DIFF
--- a/freetar/ug.py
+++ b/freetar/ug.py
@@ -82,7 +82,7 @@ class SongDetail():
         tab = tab.replace(" ", "&nbsp;")
         tab = tab.replace("[tab]", "")
         tab = tab.replace("[/tab]", "")
-        tab = re.sub(r'\[ch\]([/#\w]+)\[\/ch\]', r'<strong>\1</strong>', tab)
+        tab = re.sub(r'\[ch\]([/#\w()]+)\[\/ch\]', r'<strong>\1</strong>', tab)
         self.tab = tab
 
 


### PR DESCRIPTION
The current regex to parse chords doesn't take into account parentheses in chord symbols. One example is the `Ebm(maj7)` in [Honesty - Billy Joel](https://freetar.androidloves.me/tab/billy-joel/honesty-chords-10759) on the last line.

The regex change for parens is pretty simple, but I also made tweaks so the chord gets parsed into its components - Root, Quality, and Base (e.g. `Fm6/Ab` becomes `Fm`, `6`, `Ab`). That might be an oversimplification but I think it makes it a lot easier to do transposing which may be helpful for #6 