### PR TITLE
Fix build dependencies in Dockerfile (and #9)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.11-alpine3.18 AS builder
+RUN apk update
+RUN apk add gcc musl-dev libffi-dev
 RUN pip install poetry
 COPY . /app
 WORKDIR /app

--- a/freetar/ug.py
+++ b/freetar/ug.py
@@ -138,6 +138,8 @@ def get_chords(s: SongDetail):
                 if found:
                     variants[fret] = fingers
 
+            if not len(variants):
+                continue
             while len(variants) < 6:
                 variants[max(variants) + 1] = [0] * 6
 


### PR DESCRIPTION
This is a great project! This PR has a couple of small fixes:

- Installs Poetry dependencies in Alpine Dockerfile (`gcc`, `musl-dev`, and `libffi-dev`).
  - Not sure if this was causing problems on amd64 builds, but my image build failed without the dependencies on arm64.
- Fixes #9 by skipping chords without any variants.
  - I didn't see a clear way to still include the chords with empty `variants` lists for the cases mentioned in #9, and skipping them doesn't appear to break anything? The tab loads and looks complete to me.