### PR TITLE
fix icons and UG redirection

### DIFF
--- a/freetar/templates/tab.html
+++ b/freetar/templates/tab.html
@@ -9,7 +9,7 @@
     {% if tab.tuning %}
         Tuning: {{ tab.tuning }}<br>
     {% endif %}
-  <a class="d-print-none d-none d-md-inline" href="{{ tab.tab_url }}">View on Ultimate Guitar</a>
+  <a class="d-print-none d-none d-md-inline" href="{{ tab.tab_url }}?no_redirect">View on Ultimate Guitar</a>
   </div>
 <h5><a href="/search?search_term={{ tab.artist_name }}">{{ tab.artist_name }}</a> - {{ tab.song_name }} (ver {{tab.version }})</h5>
         Difficulty: {{ tab.difficulty }}<br>


### PR DESCRIPTION
hey, thanks for merging my previous PR. this one solves two things:

- the transpose icons are more common unicode symbols so should hopefully exist on every system
- the link to UG no includes a `?no_redirect` parameter. this makes it possible to create an redirection rule that always redirects to freetar, _except_ for if this query parameter exists. For example, see below my settings for [Redirector](https://github.com/einaregilsson/Redirector)
![screenshot_2024-01-24_12-01-41_877921823](https://github.com/kmille/freetar/assets/55081/7f7de738-d744-4e7d-b7bf-0927bc20b18d)
