### PR TITLE
Update chord parsing to handle `+` and `-` in chord symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 TODOs
+*.swp

--- a/freetar/ug.py
+++ b/freetar/ug.py
@@ -80,7 +80,7 @@ class SongDetail():
         tab = tab.replace(" ", "&nbsp;")
         tab = tab.replace("[tab]", "")
         tab = tab.replace("[/tab]", "")
-        tab = re.sub(r'\[ch\]([/#\w()]+)\[\/ch\]', r'<strong>\1</strong>', tab)
+        tab = re.sub(r'\[ch\]([/#\w()+-]+)\[\/ch\]', r'<strong>\1</strong>', tab)
         self.tab = tab
 
 


### PR DESCRIPTION
This tab has a few chords that aren't parsed: http://localhost:22000/tab/stevie-wonder/my-cherie-amour-chords-347069
- Ab7+5
- Fm7-5/Cb
- Ab13-9

Updated the chord regex to include `+` and `-`.

_Note: transposing still doesn't work on these, but that's a problem in a lot of cases. I'm going to try to take a look at improving transposing in general_
