### PR TITLE
Improve chord parsing and transposing

### DIFF
--- a/freetar/static/custom.js
+++ b/freetar/static/custom.js
@@ -30,47 +30,59 @@ function initialise_transpose() {
         transpose()
     });
 
-    $('.tab').find('strong').each(function () {
+    $('.tab').find('.chord-root, .chord-bass').each(function () {
         const text = $(this).text()
         $(this).attr('data-original', text)
     })
 
     function transpose() {
-        $('.tab').find('strong').each(function () {
-            const text = $(this).attr('data-original')
-            const new_text = transpose_chord(text.trim(), transpose_value)
-            $(this).text(new_text)
+        $('.tab').find('.chord-root, .chord-bass').each(function () {
+            const originalText = $(this).attr('data-original')
+            if (transpose_value === 0) {
+                $(this).text(originalText)
+            } else {
+                const new_text = transpose_note(originalText.trim(), transpose_value)
+                $(this).text(new_text)
+            }
         });
     }
 
-    const variations = ['', 'dim', 'm', 'm7', 'maj7', '7', 'sus4', 'sus2', 'sus', 'dim7', 'min7b5', '7sus4', '6', 'm6', '9', 'm9', 'maj9', '11', 'add2', 'add9']
-    const notes = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', "A", 'A#', 'B']
-    const notesFlat = ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', "A", 'Bb', 'B']
+    // Defines a list of notes, grouped with any alternate names (like D# and Eb)
+    const noteNames = [
+        ['A'],
+        ['A#', 'Bb'],
+        ['B','Cb'],
+        ['C', 'B#'],
+        ['C#', 'Db'],
+        ['D'],
+        ['D#', 'Eb'],
+        ['E', 'Fb'],
+        ['F', 'E#'],
+        ['F#', 'Gb'],
+        ['G'],
+        ['G#', 'Ab'],
+    ];
 
-    const chords = notes.map(note => variations.map(variation => note + variation))
-    const chordsFlat = notesFlat.map(note => variations.map(variation => note + variation))
-        
+    // Find the given note in noteNames, then step through the list to find the
+    // next note up or down. Currently just selects the first note name that
+    // matches. It doesn't preserve sharp, flat, or any try to determine what
+    // key we're in.
+    function transpose_note(note, transpose_value) {
 
-    function transpose_chord(chord, transpose_value) {
-        if (chord.indexOf('/') !== -1) {
-            const transposed = chord.split('/').map(cho => transpose_chord(cho, transpose_value))
-            return transposed.join('/')
+        let noteIndex = noteNames.findIndex(tone => tone.includes(note));
+        if (noteIndex === -1)
+        {
+            console.debug("Note ["+note+"] not found. Can't transpose");
+            return note;
         }
-        let chordGroup = chords;
-        let chord_index = chords.findIndex(chordGroup => chordGroup.includes(chord))
-        if (chord_index === -1) {
-            chordGroup = chordsFlat;
-            chord_index = chordsFlat.findIndex(chordGroup => chordGroup.includes(chord))
-            if (chord_index === -1) {
-                return chord
-            }
-        }
-        let new_index = (chord_index + transpose_value) % 12
+
+        let new_index = (noteIndex + transpose_value) % 12;
         if (new_index < 0) {
-            new_index += 12
+            new_index += 12;
         }
 
-        return chordGroup[new_index][chordGroup[chord_index].indexOf(chord)]
+        // TODO: Decide on sharp, flat, or natural
+        return noteNames[new_index][0];
     }
 }
 

--- a/freetar/ug.py
+++ b/freetar/ug.py
@@ -80,8 +80,23 @@ class SongDetail():
         tab = tab.replace(" ", "&nbsp;")
         tab = tab.replace("[tab]", "")
         tab = tab.replace("[/tab]", "")
-        tab = re.sub(r'\[ch\]([/#\w()+-]+)\[\/ch\]', r'<strong>\1</strong>', tab)
+
+        # (?P<root>[A-Ga-g](#|b)?) : Chord root is any letter A - G with an optional sharp or flat at the end
+        # (?P<quality>[^[/]+)?  : Chord quality is anything after the root, but before the `/` for the base note
+        # (?P<bass>/[A-Ga-g](#|b)?)? :  Chord quality is anything after the root, including parens in the case of 'm(maj7)'
+        # tab = re.sub(r'\[ch\](?P<root>[A-Ga-g](#|b)?)(?P<quality>[#\w()]+)?(?P<bass>/[A-Ga-g](#|b)?)?\[\/ch\]', self.parse_chord, tab)
+        tab = re.sub(r'\[ch\](?P<root>[A-Ga-g](#|b)?)(?P<quality>[^[/]+)?(?P<bass>/[A-Ga-g](#|b)?)?\[\/ch\]', self.parse_chord, tab)
         self.tab = tab
+
+    def parse_chord(self, chord):
+        root = '<span class="chord-root">%s</span>' % chord.group('root')
+        quality = ''
+        bass = ''
+        if chord.group('quality') is not None:
+            quality = '<span class="chord-quality">%s</span>' % chord.group('quality')
+        if chord.group('bass') is not None:
+            bass = '/<span class="chord-bass">%s</span>' % chord.group('bass')[1:]
+        return '<span class="chord fw-bold">%s</span>' % (root + quality + bass)
 
 
 def ug_search(value: str):


### PR DESCRIPTION
I've found a few places where chords aren't transposing:
- [Honesty - Billy Joel](http://localhost:22000/tab/billy-joel/honesty-chords-10759)
    - `F9sus`
    - `C9sus4`
    - `Ebm(maj7)`
- [My Cherie Amour - Stevie Wonder](http://localhost:22000/tab/stevie-wonder/my-cherie-amour-chords-347069)
    - `Cbmaj7`(this one fails because of the `Cb`)
    - `Ab13`
- [You've Got a Friend in Me - Randy Newman](http://localhost:22000/tab/misc-cartoons/toy-story-youve-got-a-friend-in-me-chords-107274)
    - `Gaug`

The current transpose logic is trying to parse the chord based on a [list of chord qualities](https://github.com/kmille/freetar/blob/fa4dddd70f92e4ce452f37b55adc0a1f63816e83/freetar/static/custom.js#L46), but the list is incomplete. The chord quality doesn't really matter for transposing, though. Only the chord root and the base note. So `Emaj7/B` transposes up to `Fmaj7/C` (`maj7` stays the same).

I made changes to the chord parsing regex to separate out the chord into **Chord**, **Quality**, and **Base**.
![Screenshot from 2024-02-23 00-50-48](https://github.com/kmille/freetar/assets/18602386/50455386-b36d-4c4f-a6cc-385aa5a90e05)

This makes it so the javascript that does the transposing can immediately go to the `span` containing the **root** and **base**, without worrying about parsing the **quality**.

### Potential Issues
1. The RegEx that parses the chords is hard to read. Let me know if it's a problem
2. The code doesn't do anything to preserve sharps or flats when transposing. The order of precedence is "natural", "sharp", "flat"

Let me know if any of those issues would need to be fixed