### PR TITLE
Improve auto-scrolling so user scrolling isn't blocked

### DIFF
--- a/freetar/static/custom.js
+++ b/freetar/static/custom.js
@@ -1,6 +1,3 @@
-scroll_timeout = 500;
-do_scroll = true;
-
 function colorize_favs() {
     // make every entry yellow if we faved it before
     favorites = JSON.parse(localStorage.getItem("favorites")) || {};
@@ -86,29 +83,11 @@ function initialise_transpose() {
     }
 }
 
-
 $(document).ready(function () {
     colorize_favs();
     initialise_transpose();
 });
 
-function pageScroll() {
-    console.log(scroll_timeout);
-    window.scrollBy(0, 3);
-    if (do_scroll) {
-        scrolldelay = setTimeout(pageScroll, scroll_timeout);
-    }
-}
-
-$('#checkbox_autoscroll').click(function () {
-    if ($(this).is(':checked')) {
-        do_scroll = true;
-        pageScroll();
-    } else {
-        scroll_timeout = 500;
-        do_scroll = false;
-    }
-});
 
 $('#checkbox_view_chords').click(function(){
     if($(this).is(':checked')){
@@ -140,9 +119,9 @@ document.querySelectorAll('.favorite').forEach(item => {
     } else {
       const fav = {
         artist_name: elm.getAttribute('data-artist'),
-        song: elm.getAttribute('data-song'),        
-        type: elm.getAttribute('data-type'),        
-        rating: elm.getAttribute('data-rating'),  
+        song: elm.getAttribute('data-song'),
+        type: elm.getAttribute('data-type'),
+        rating: elm.getAttribute('data-rating'),
         tab_url: elm.getAttribute('data-url')
       }
       favorites[fav["tab_url"]] = fav;

--- a/freetar/static/scroll.js
+++ b/freetar/static/scroll.js
@@ -1,57 +1,78 @@
-// const SCROLL_STEP_SIZE = 3;
 const SCROLL_STEP_SIZE = 3;
-scroll_timeout = 500;
-do_scroll = false;
-safePageScroll = debouncedPageScrollFactory(pageScroll);
+const SCROLL_TIMEOUT_MINIMUM = 50;
+const SCROLL_DELAY_AFTER_USER_ACTION = 500;
 
-function pageScroll(timeoutOverride) {
-    console.log(scroll_timeout);
-    window.scrollBy(0, SCROLL_STEP_SIZE);
-    if (do_scroll) {
-        safePageScroll();
-    }
-}
+let pausedForUserInteraction = false;
+let scrollTimeout = 500;
+let scrollInterval = null;
+let pauseScrollTimeout = null;
+
+$('#checkbox_autoscroll').prop("checked", false);
+
+
+/*****************
+ * Event Handlers
+ *****************/
 
 $('#checkbox_autoscroll').click(function () {
     if ($(this).is(':checked')) {
-        do_scroll = true;
-        safePageScroll();
+        startScrolling();
     } else {
-        // scroll_timeout = 500;
-        do_scroll = false;
+        stopScrolling();
     }
 });
 
-$(window).on("scroll", function() {
-    // Reset the timeout
-    if (do_scroll)
-    {
-        safePageScroll();
-    }
+$(window).on("wheel touchmove", function() {
+    pauseScrolling(SCROLL_DELAY_AFTER_USER_ACTION);
 });
 
 $('#scroll_speed_down').click(function () {
     // Increase the delay to slow down scroll
-    scroll_timeout += 50;
-    if (do_scroll)
-    {
-        safePageScroll();
-    }
+    scrollTimeout += 50;
+    pauseScrolling(SCROLL_DELAY_AFTER_USER_ACTION);
+    startScrolling();
 });
 
 $('#scroll_speed_up').click(function () {
-    // Decrease the delay to speed up scroll
-    scroll_timeout -= 50;
-    if (do_scroll)
-    {
-        safePageScroll("blah");
-    }
+    // Decrease the delay to speed up scroll.
+    // Don't decrease the delay all the way to 0
+    scrollTimeout = Math.max(50, scrollTimeout - 50);
+    pauseScrolling(SCROLL_DELAY_AFTER_USER_ACTION);
+    startScrolling();
 });
 
-function debouncedPageScrollFactory (func) {
-    let timer;
-    return (...args) => {
-        clearTimeout(timer);
-        timer = setTimeout(() => { func.apply(this, args); }, scroll_timeout);
-    };
+
+/*******************
+ * Scroll Functions
+ ******************/
+
+// Scroll the page by SCROLL_STEP_SIZE
+// Will not do anything if `pausedForUserInteraction` is set to `true`
+function pageScroll() {
+    if (pausedForUserInteraction) { return; }
+
+    window.scrollBy(0, SCROLL_STEP_SIZE);
 }
+
+// Sets up the `pageScroll` function to be called in a loop every
+// `scrollTimeout` milliseconds
+function startScrolling() {
+    if (scrollInterval) {
+        clearInterval(scrollInterval);
+    }
+    scrollInterval = setInterval(pageScroll, scrollTimeout);
+}
+
+// Sets `pausedForUserInteraction` to `true` for `delay` miliseconds. 
+// Will stop `pageScroll` from actually scrolling the page
+function pauseScrolling(delay) {
+    pausedForUserInteraction = true;
+    clearTimeout(pauseScrollTimeout);
+    pauseScrollTimeout = setTimeout(() => pausedForUserInteraction = false, delay);
+}
+
+// Clears the interval that got set up in `startScrolling`
+function stopScrolling() {
+    clearInterval(scrollInterval);
+}
+

--- a/freetar/static/scroll.js
+++ b/freetar/static/scroll.js
@@ -29,16 +29,23 @@ $(window).on("wheel touchmove", function() {
 $('#scroll_speed_down').click(function () {
     // Increase the delay to slow down scroll
     scrollTimeout += 50;
-    pauseScrolling(SCROLL_DELAY_AFTER_USER_ACTION);
-    startScrolling();
+    if (scrollInterval !== null)
+    {
+        pauseScrolling(SCROLL_DELAY_AFTER_USER_ACTION);
+        startScrolling();
+    }
 });
 
 $('#scroll_speed_up').click(function () {
     // Decrease the delay to speed up scroll.
     // Don't decrease the delay all the way to 0
     scrollTimeout = Math.max(50, scrollTimeout - 50);
-    pauseScrolling(SCROLL_DELAY_AFTER_USER_ACTION);
-    startScrolling();
+
+    if (scrollInterval !== null)
+    {
+        pauseScrolling(SCROLL_DELAY_AFTER_USER_ACTION);
+        startScrolling();
+    }
 });
 
 

--- a/freetar/static/scroll.js
+++ b/freetar/static/scroll.js
@@ -1,0 +1,57 @@
+// const SCROLL_STEP_SIZE = 3;
+const SCROLL_STEP_SIZE = 3;
+scroll_timeout = 500;
+do_scroll = false;
+safePageScroll = debouncedPageScrollFactory(pageScroll);
+
+function pageScroll(timeoutOverride) {
+    console.log(scroll_timeout);
+    window.scrollBy(0, SCROLL_STEP_SIZE);
+    if (do_scroll) {
+        safePageScroll();
+    }
+}
+
+$('#checkbox_autoscroll').click(function () {
+    if ($(this).is(':checked')) {
+        do_scroll = true;
+        safePageScroll();
+    } else {
+        // scroll_timeout = 500;
+        do_scroll = false;
+    }
+});
+
+$(window).on("scroll", function() {
+    // Reset the timeout
+    if (do_scroll)
+    {
+        safePageScroll();
+    }
+});
+
+$('#scroll_speed_down').click(function () {
+    // Increase the delay to slow down scroll
+    scroll_timeout += 50;
+    if (do_scroll)
+    {
+        safePageScroll();
+    }
+});
+
+$('#scroll_speed_up').click(function () {
+    // Decrease the delay to speed up scroll
+    scroll_timeout -= 50;
+    if (do_scroll)
+    {
+        safePageScroll("blah");
+    }
+});
+
+function debouncedPageScrollFactory (func) {
+    let timer;
+    return (...args) => {
+        clearTimeout(timer);
+        timer = setTimeout(() => { func.apply(this, args); }, scroll_timeout);
+    };
+}

--- a/freetar/templates/base.html
+++ b/freetar/templates/base.html
@@ -53,6 +53,7 @@
   </div>
 
   <script src="/static/custom.js"></script>
+  <script src="/static/scroll.js"></script>
 
   <!-- Optional JavaScript; choose one of the two! -->
 

--- a/freetar/templates/tab.html
+++ b/freetar/templates/tab.html
@@ -30,8 +30,8 @@
         <div class="form-check form-switch autoscroll me-4">
           <input class="form-check-input" type="checkbox" role="switch" id="checkbox_autoscroll" />
           <label class="form-check-label" for="checkbox_autoscroll">Autoscroll</label>
-        <span role="button" title="decrease scroll speed" class="m-2" onclick="scroll_timeout+=50" >❮❮</span>
-        <span role="button" title="increase scroll speed" class="m-2" onclick="scroll_timeout-=50" >❯❯</span>
+        <span role="button" id="scroll_speed_down" title="decrease scroll speed" class="m-2" >❮❮</span>
+        <span role="button" id="scroll_speed_up" title="increase scroll speed" class="m-2" >❯❯</span>
         </div>
    
   <div>


### PR DESCRIPTION
Auto-scrolling blocks users from being able to scroll, especially at faster speeds. Chrome handles it a little better than Firefox but still has issues.
Changes:
1. Moved the scroll logic into it's own file for readability
2. Changed from `setTimeout` to `setInterval`
3. Pause auto-scroll when ever a user:
    - uses the mouse wheel
    - touches and drags the screen
    - clicks the speed up or slow down buttons

**Known issue**: Auto-scroll still conflicts with using the scroll bar. I think the `scroll` event is the only way to detect that, but `scrollBy` triggers the same event so there's no way to tell them apart

Feel free to suggest any changes.