### PR TITLE
Route to the correct render template when using tabids

### DIFF
--- a/freetar/backend.py
+++ b/freetar/backend.py
@@ -39,7 +39,7 @@ def show_tab(artist: str, song: str):
 @app.route("/tab/<tabid>")
 def show_tab2(tabid: int):
     tab = ug_tab(tabid)
-    return render_template("index.html",
+    return render_template("tab.html",
                            tab=tab,
                            title=f"{tab.artist_name} - {tab.song_name}")
 


### PR DESCRIPTION
Some tabs use `tab/<tabid>` route. That route is currently using the `index.html` render template instead of the `tab.html` template.
Here's an example of a tab that's not displaying: http://localhost:22000/tab/2325183