### PR TITLE
Fix newline parsing

### DIFF
--- a/freetar/ug.py
+++ b/freetar/ug.py
@@ -77,6 +77,7 @@ class SongDetail():
     def fix_tab(self):
         tab = self.tab
         tab = tab.replace("\r\n", "<br/>")
+        tab = tab.replace("\n", "<br/>")
         tab = tab.replace(" ", "&nbsp;")
         tab = tab.replace("[tab]", "")
         tab = tab.replace("[/tab]", "")


### PR DESCRIPTION
UG has apparently started migrating the tab format from the CRLF line-ending format to the LF line-ending format.

Thus, some tabs now appear broken (e.g. [Space Oddity](https://freetar.de/tab/david-bowie/space-oddity-chords-105869)). This change regards single LF characters as newlines as well and fixes the broken tabs.