### PR TITLE
Don't crash when the package version is unknown

### DIFF
--- a/freetar/utils.py
+++ b/freetar/utils.py
@@ -2,7 +2,10 @@ import importlib.metadata
 
 
 def get_version():
-    return importlib.metadata.version(__package__)
+    try:
+        return importlib.metadata.version(__package__)
+    except importlib.metadata.PackageNotFoundError:
+        return 'development'
 
 
 class FreetarError(Exception):


### PR DESCRIPTION
When running the module directly from command line without a python package, importlib doesn't know the package version and this causes freetar to crash.

This commit assumes "development" as the version if a version is not available, instead of crashing.