### PR TITLE
fix artist link redirecting to UG instead of freetar

### DIFF
--- a/freetar/templates/index.html
+++ b/freetar/templates/index.html
@@ -17,7 +17,7 @@
       <tbody>
           {% for result in search_results %}
           <tr>
-              <td class="artist"><a href="{{ result.artist_url}}">{{ result.artist_name}}</a></td>
+              <td class="artist"><a href="/search?search_term={{ result.artist_name }}">{{ result.artist_name}}</a></td>
               <td class="song"><a href="{{ result.tab_url}}">{{ result.song_name}} (ver {{result.version}})</a></td>
               <td class="rating" data-value="{{ result.rating }}">{{ result.rating}}/5 ({{result.votes}})</td>
               <td class="type">{{ result._type}}</td>


### PR DESCRIPTION
The artist link in the results of a search now correctly points back to freetar instead of Ultimate Guitar.