### PR TITLE
Sharp/flats toggle

### DIFF
--- a/freetar/static/custom.js
+++ b/freetar/static/custom.js
@@ -26,6 +26,11 @@ $('#checkbox_autoscroll').click(function () {
     }
 });
 
+$('#checkbox_use_flats').click(function () {
+    console.log("Use flats: " + $(this).is(':checked'));
+    initialise_transpose();
+});
+
 $(window).on("wheel touchmove", function() {
     pauseScrolling(SCROLL_DELAY_AFTER_USER_ACTION);
 });
@@ -109,6 +114,7 @@ function initialise_transpose() {
     //const current = $('#transpose .current')
     const minus = $('#transpose_down')
     const plus = $('#transpose_up')
+    const flats = $('#checkbox_use_flats')
     //current.text(transpose_value)
     plus.click(function () {
         transpose_value = Math.min(11, transpose_value + 1)
@@ -120,6 +126,10 @@ function initialise_transpose() {
         //current.text(transpose_value)
         transpose()
     });
+    flats.click(function () {
+        transpose_value = 0
+        transpose()
+    });
 
     $('.tab').find('.chord-root, .chord-bass').each(function () {
         const text = $(this).text()
@@ -128,13 +138,11 @@ function initialise_transpose() {
 
     function transpose() {
         $('.tab').find('.chord-root, .chord-bass').each(function () {
-            const originalText = $(this).attr('data-original')
-            if (transpose_value === 0) {
-                $(this).text(originalText)
-            } else {
-                const new_text = transpose_note(originalText.trim(), transpose_value)
+            const originalText = $(this).attr('data-original');
+            const use_flats = $('#checkbox_use_flats').is(':checked');
+
+            const new_text = transpose_note(originalText.trim(), transpose_value, use_flats)
                 $(this).text(new_text)
-            }
         });
     }
 
@@ -142,13 +150,13 @@ function initialise_transpose() {
     const noteNames = [
         ['A'],
         ['A#', 'Bb'],
-        ['B','Cb'],
-        ['C', 'B#'],
+        ['B'],
+        ['C'],
         ['C#', 'Db'],
         ['D'],
         ['D#', 'Eb'],
-        ['E', 'Fb'],
-        ['F', 'E#'],
+        ['E'],
+        ['F'],
         ['F#', 'Gb'],
         ['G'],
         ['G#', 'Ab'],
@@ -158,7 +166,7 @@ function initialise_transpose() {
     // next note up or down. Currently just selects the first note name that
     // matches. It doesn't preserve sharp, flat, or any try to determine what
     // key we're in.
-    function transpose_note(note, transpose_value) {
+    function transpose_note(note, transpose_value, use_flats = false) {
 
         let noteIndex = noteNames.findIndex(tone => tone.includes(note));
         if (noteIndex === -1)
@@ -172,7 +180,13 @@ function initialise_transpose() {
             new_index += 12;
         }
 
-        // TODO: Decide on sharp, flat, or natural
+        if (use_flats) {
+            // If we want to use flats, we need to check if the new note is a flat
+            // and if so, return the first flat name
+            if (noteNames[new_index].length > 1) {
+                return noteNames[new_index][1];
+            }
+        }
         return noteNames[new_index][0];
     }
 }

--- a/freetar/templates/tab.html
+++ b/freetar/templates/tab.html
@@ -52,6 +52,12 @@
           <span role="button" id="transpose_down" title="transpose down" class="m-2">↓</span>
           <span role="button" id="transpose_up" title="transpose up" class="m-2">↑</span>
       </div>
+
+      <div class="form-check form-switch me-4">
+          <input class="form-check-input" type="checkbox" role="switch" id="checkbox_use_flats"/>
+          <label class="form-check-label" for="checkbox_use_flats">Use flats (♭)</label>
+      </div>
+
   </div>
 
     <hr class="border border-primary"/>


### PR DESCRIPTION
Hi! Thanks a lot for your project!!
I just started using it, but I noticed you haven't implemented a toggle between sharp notes (e.g., C#) and flat versions (e.g., Db).
I haven't found any requests or pull requests already, so here's my attempt -- I'm not a JS developer, so I tried my best.

For the music theorists out there: I chose to implement this by committing the cardinal sin of ignoring edge cases such as B#, Cb, Fb, E#. I prefer favoring legibility over technical correctness. The toggles switches between the following notes:

```
A# -> Bb
C# -> Db
D# -> Eb
F# -> Gb
G# -> Ab
```