### PR TITLE
Add support for video content

### DIFF
--- a/freetar/templates/tab.html
+++ b/freetar/templates/tab.html
@@ -14,6 +14,7 @@
      View on <a class="d-print-none" href="{{ tab.tab_url }}?no_redirect">Ultimate Guitar</a>
   </div>
 
+  {% if tab._type != "Video" %}
   <div class="col-sm col-md-9 col-lg-9">
     Difficulty: {{ tab.difficulty }}<br>
   </div>
@@ -32,8 +33,7 @@
          Tuning: {{ tab.tuning }}<br>
      {% endif %}
   </div>
-    
-    
+
   <div class="d-flex align-items-center d-print-none flex-wrap">
       <div class="form-check form-switch autoscroll me-4">
           <input class="form-check-input" type="checkbox" role="switch" id="checkbox_autoscroll" />
@@ -60,6 +60,7 @@
           <span role="button" id="columns_down" title="remove column" class="m-2">-</span>
       </div>
   </div>
+  {% endif %}
 
     <hr class="border border-primary"/>
     <div id="chordVisuals" style="display: none;">
@@ -98,7 +99,13 @@
     </div>
 
     <div class="tab font-monospace">
+	{% if tab._type == "Video" %}
+	<div class="ratio ratio-16x9">
+	    <iframe src="https://www.youtube-nocookie.com/embed/{{tab.tab}}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+	</div>
+	{% else %}
         {{ tab.tab | safe }} 
+	{% endif %}
     </div>
 
     {% if tab.alternatives %}


### PR DESCRIPTION
Embed the linked YouTube video in the tab page. Exclude chord-specific elements.