### PR TITLE
Add option to change the color of the chords

### DIFF
--- a/freetar/backend.py
+++ b/freetar/backend.py
@@ -5,7 +5,7 @@ from flask_caching import Cache
 from flask_minify import Minify
 
 from freetar.ug import Search, ug_tab
-from freetar.utils import get_version, FreetarError
+from freetar.utils import get_version, get_bootstrap_colors, FreetarError
 
 cache = Cache(config={'CACHE_TYPE': 'SimpleCache',
                       "CACHE_DEFAULT_TIMEOUT": 0,
@@ -52,6 +52,7 @@ def show_tab(artist: str, song: str):
     tab = ug_tab(f"{artist}/{song}")
     return render_template("tab.html",
                            tab=tab,
+                           bootstrap_colors=get_bootstrap_colors(),
                            title=f"{tab.artist_name} - {tab.song_name}")
 
 
@@ -61,6 +62,7 @@ def show_tab2(tabid: int):
     tab = ug_tab(tabid)
     return render_template("tab.html",
                            tab=tab,
+                           bootstrap_colors=get_bootstrap_colors(),
                            title=f"{tab.artist_name} - {tab.song_name}")
 
 

--- a/freetar/templates/tab.html
+++ b/freetar/templates/tab.html
@@ -59,6 +59,41 @@
           <span role="button" id="columns_up" title="add column" class="m-2">+</span>
           <span role="button" id="columns_down" title="remove column" class="m-2">-</span>
       </div>
+
+      <div class="dropdown">
+        <style>
+            :root {
+                --chords-color: var(--bs-body-color);
+            }
+
+            .color-swatch {
+                width: 1.5rem;
+                height: 1.5rem;
+                padding: 0;
+                border: 1px solid var(--bs-border-color);
+            }
+            .color-swatch:has(.btn-check:checked) {
+                outline: 2px solid var(--bs-body-color);
+                outline-offset: 1px;
+                border: none;
+            }
+            .chord {
+                color: var(--chords-color, var(--bs-body-color));
+            }
+        </style>
+        <button class="btn btn-sm dropdown-toggle d-flex align-items-center gap-1" type="button" id="chordColorDropdown" data-bs-toggle="dropdown" aria-expanded="false" title="Select chords color">
+            <span id="currentColorIndicator" class="border border-secondary-subtle rounded-circle" style="width: 1.25em; height: 1.25em; background-color: var(--chords-color);"></span>
+        </button>
+        <div class="dropdown-menu p-2 shadow-sm" aria-labelledby="chordColorDropdown" style="min-width: 7rem;">
+            <div class="d-flex flex-wrap gap-2 justify-content-evenly" id="chordColorPalette">
+                {% for color in bootstrap_colors %}
+                    <label class="btn color-swatch" style="background-color: var({{ color }});">
+                        <input type="radio" class="btn-check" name="chordColor" value="{{ color }}">
+                    </label>
+                {% endfor %}
+            </div>
+        </div>
+      </div>
   </div>
 
     <hr class="border border-primary"/>
@@ -116,8 +151,10 @@
 
 
 <script>
-    document.addEventListener("DOMContentLoaded", function () {
+    document.documentElement.style.setProperty("--chords-color", `var(${localStorage.getItem("chords_color") || "--bs-body-color"})`);
 
+    document.addEventListener("DOMContentLoaded", function () {
+        // Set favorite star's color to gold if this song is in the user's favorites
         const favorites = JSON.parse(localStorage.getItem("favorites")) || {};
         if (window.location.pathname in favorites) {
             console.log("True!");
@@ -126,8 +163,25 @@
             });
         }
 
+        // Set/update the chords highlight color
+        set_chords_color(document.documentElement.style.getPropertyValue("--chords-color").slice(4, -1));
+        document.getElementById("chordColorPalette")?.addEventListener("change", e => set_chords_color(e.target.value));
     });
 
+    function set_chords_color(color) {
+        // If the given `color` is invalid, set it to the default value
+        if (!color) color = "--bs-body-color";
+
+        // Update the chords color CSS variable
+        document.documentElement.style.setProperty("--chords-color", `var(${color})`);
+        // Update the radio button selection in the color selection dropdown menu
+        const radio = document.querySelector(`input[name="chordColor"][value="${color}"]`);
+        if (radio) radio.checked = true;
+
+        // Save color selection to local storage
+        localStorage.setItem("chords_color", color);
+    }
 </script>
+<script defer src="/static/bootstrap/bootstrap.bundle.min.js"></script>
 
 {% endblock %}

--- a/freetar/utils.py
+++ b/freetar/utils.py
@@ -7,6 +7,14 @@ def get_version():
     except importlib.metadata.PackageNotFoundError:
         return 'development'
 
+def get_bootstrap_colors():
+    return [
+      "--bs-body-color", "--bs-secondary-color", "--bs-tertiary-color",
+      "--bs-teal", "--bs-success", "--bs-success-border-subtle",
+      "--bs-info", "--bs-primary", "--bs-primary-border-subtle",
+      "--bs-pink", "--bs-purple", "--bs-indigo",
+      "--bs-warning", "--bs-danger", "--bs-danger-border-subtle",
+    ]
 
 class FreetarError(Exception):
     pass


### PR DESCRIPTION
This PR adds the ability to change the color of the chords, as suggested at #83.

---

# Description
It adds a button (after the "Columns" button) that opens a small dropdown menu that allows the user to choose their preferred color from a list of predefined colors.
Instead of using the actual absolute value of the color, I used the CSS variable names of Bootstrap's theme colors - so they would automatically work in both light and dark mode. The list of available colors is defined in `utils.py`, and can be easily changed later in development.
The selected color is saved to localStorage, so the user doesn't have to manually change it each time they reload the page or go to a different song. If there's no color saved in localStorage (or there's an error), it uses the default color. I choose the default color to be the same color that's currently used on the website (`--bs-body-color`), to avoid potentially annoying existing users who might like it how it is now.

# Screenshots (in both light & dark mode)
### Here is a screenshot of the color selection menu:
<img width="400" height="280" alt="ColorSelectorDropdownMenu" src="https://github.com/user-attachments/assets/0a8a6b7c-12e3-4b24-9ae5-fdc3fbb85ceb" />

### And here is a screenshot of the colored chords:
<img width="1340" height="830" alt="ChordsColorHotelCalifornia" src="https://github.com/user-attachments/assets/eaa6b21c-7604-4c57-97e4-48fd91a19c8a" />
