### PR TITLE
Add `FREETAR_LOCAL` mode to restore local functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ After successful installation, there is an executable called `freetar` in the PA
 * `FREETAR_HOST`
 * `FREETAR_PORT`
 * `FREETAR_CACHE_TIMEOUT` (how log should tabs be cached in memory, reduces the requests to Ultimate Guitar, defaults to 0 (inifnity))
+* `FREETAR_LOCAL=1` fetches directly from Ultimate Guitar instead of the public Freetar proxies.
 
 **PyPi**  
 Package: https://pypi.org/project/freetar/
@@ -69,6 +70,7 @@ Visit localhost:22000 in browser
 # static files: freetar/static/*
 # html templates: freetar/templates/*
 FREETAR_CACHE_TIMEOUT=1 uv run freetar
+FREETAR_LOCAL=1 uv run freetar
 ```
 
 ## Future work

--- a/freetar/ug.py
+++ b/freetar/ug.py
@@ -2,10 +2,18 @@ import requests
 from bs4 import BeautifulSoup
 from urllib.parse import quote, urlparse
 import json
+import os
 import re
 
 from dataclasses import dataclass, field
 from .utils import FreetarError
+
+LOCAL_MODE = os.environ.get("FREETAR_LOCAL") == "1"
+REQUEST_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                  "AppleWebKit/537.36 (KHTML, like Gecko) "
+                  "Chrome/126.0.0.0 Safari/537.36",
+}
 
 
 @dataclass
@@ -104,7 +112,12 @@ class Search:
 
     def __init__(self, value: str, page: int):
         try:
-            resp = requests.get(f"https://proxy.freetar.de/search.php?page={page}&search_type=title&value={quote(value)}")
+            if LOCAL_MODE:
+                resp = requests.get("https://www.ultimate-guitar.com/search.php",
+                                    params={"page": page, "search_type": "title", "value": value},
+                                    headers=REQUEST_HEADERS)
+            else:
+                resp = requests.get(f"https://proxy.freetar.de/search.php?page={page}&search_type=title&value={quote(value)}")
             resp.raise_for_status()
             bs = BeautifulSoup(resp.text, 'html.parser') # data can be None
             data = bs.find("div", {"class": "js-store"}) # KeyError
@@ -187,7 +200,11 @@ def get_chords(s: SongDetail) -> SongDetail:
 
 def ug_tab(url_path: str):
     try:
-        resp = requests.get("https://tabs.proxy.freetar.de/tab/" + url_path)
+        if LOCAL_MODE:
+            resp = requests.get("https://tabs.ultimate-guitar.com/tab/" + str(url_path),
+                                headers=REQUEST_HEADERS)
+        else:
+            resp = requests.get("https://tabs.proxy.freetar.de/tab/" + url_path)
         resp.raise_for_status()
         bs = BeautifulSoup(resp.text, 'html.parser')
         data = bs.find("div", {"class": "js-store"})


### PR DESCRIPTION
`proxy.freetar.de` appears to be blocked by Ultimate Guitar, which breaks all Freetar instances.

This adds `FREETAR_LOCAL=1` for local runs. This requests Ultimate Guitar directly from the user's machine with a browser User-Agent instead of routing through the proxy.

This does not fix hosted Freetar instances, where the hosted backend still has to make the request. But it should restore functionality for users running Freetar locally.

Ultimate Guitar may still rate-limit, block, or present a Cloudflare challenge to these local requests, but this has worked in limited local testing.